### PR TITLE
added a build action, that builds workbench on the build branch.

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,12 @@
+name: build
+on:
+  push:
+    branches: [ build ]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build the Docker image
+      run: ./workbench.sh build
+      continue-on-error: true # due to exit 11


### PR DESCRIPTION
This is a *stub* (feel free *not* to merge).

Next step would be to figure: https://github.com/satackey/action-docker-layer-caching/blob/main/action.yml as currently `./workbench.sh build` takes 26 minutes, which would consume too much compute without caching. Another approach would be to have an action that pushes the image, and the test ones that pull it.

Anyway workbench works smoothly so the need for actions is questionable.